### PR TITLE
Minor improvements

### DIFF
--- a/mediameter/cliff.py
+++ b/mediameter/cliff.py
@@ -1,6 +1,13 @@
 import logging, json
 import requests
 
+
+_placename_replaces = [
+    ('Washington, DC', 'Washington DC'),
+    ('Washington, D.C.', 'Washington DC'),
+]
+
+
 class Cliff():
     '''
     Make requests to a CLIFF geo-parsing / NER server
@@ -22,6 +29,8 @@ class Cliff():
         self._log.info("initialized CLIFF @ %s:%d", self._host,self._port)
 
     def parseText(self,text,demonyms=False):
+        for target, replace in _placename_replaces:
+            text = text.replace(target, replace)
         return self._parseQuery(self.PARSE_TEXT_PATH, text, demonyms)
 
     def parseSentences(self,json_object,demonyms=False):

--- a/mediameter/cliff.py
+++ b/mediameter/cliff.py
@@ -41,13 +41,13 @@ class Cliff():
 
     def _parseQuery(self,path,text,demonyms=False):
         payload = {'q':text,'replaceAllDemonyms':self._demonymsText(demonyms)}
-        self._log.debug("Querying "+path+" (demonyms="+str(demonyms)+")")
+        self._log.debug("Querying %r (demonyms=%r)", path, demonyms)
         return self._query(path,payload)
     
     def _query(self,path,args):
         try:
             r = requests.post( self._urlTo(path), data=args)
-            self._log.debug('CLIFF says '+r.content)
+            self._log.debug('CLIFF says %r', r.content)
             return r.json()
         except requests.exceptions.RequestException as e:
             self._log.exception(e)

--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,14 @@ version = ''
 with open('mediameter/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
 
-if sys.argv[1]=="sdist":
-    try:
-        import pypandoc
-        long_description = pypandoc.convert('README.md', 'rst')
-    except(IOError, ImportError) as e:
-        long_description = open('README.md').read()
-        logging.exception(e)
-    f = open('README.rst', 'w')
-    f.write(long_description)
-    f.close()
-
-readme_rst = ''
-with open('README.rst', 'r') as f:
-    readme_rst = f.read()
+readme = ''
+with open('README.md', 'r') as f:
+    readme = f.read()
 
 setup(name='mediameter-cliff',
     version=version,
     description='MediaMeter CLIFF API Client Library',
-    long_description=readme_rst,
+    long_description=readme,
     author='Rahul Bhargava',
     author_email='rahulb@media.mit.edu',
     url='http://cliff.mediameter.org',


### PR DESCRIPTION
We're using Cliff for geoparsing in a Python 3 application and encountered a few difficulties addressed in this PR

- avoid `bytestring` vs `str` error in Py 3
- avoid hard requirement on pypandoc for `setup.py install`
- handle placename replacements to avoid e.g. `'Washington, D.C.'` parsed as Washington state.

If you'd prefer to see these as separate PRs, can do so. 